### PR TITLE
build(hugo): already using relative urls

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -4,7 +4,6 @@ languageCode = "en-us"
 title = "Texas Butterfly Monitoring Network"
 copyright = """Copyright © 2021 Texas Butterfly Monitoring Network"""
 disableKinds = ["taxonomy", "term"]
-relativeURLs = true
 pathWarnings = true
 [markup]
   [markup.tableOfContents]

--- a/config/development/config.toml
+++ b/config/development/config.toml
@@ -3,3 +3,4 @@
 verbose = true
 verboseLog = true
 minify = false
+baseURL = "http://localhost/preview"


### PR DESCRIPTION
Because the templates and content files are all using relative URLs, the `hugo` config `relativeURLs` is not needed.